### PR TITLE
Use stored task pointer for Task deletion

### DIFF
--- a/components/pnitask/pnitask.cpp
+++ b/components/pnitask/pnitask.cpp
@@ -44,8 +44,10 @@ bool Task::start() {
 }
 
 void Task::cancel() {
-    vTaskDelete(0);
-    mTask = 0;
+    if (mTask != 0) {
+        vTaskDelete(mTask);
+        mTask = 0;
+    }
 }
 
 void Task::taskFunc( void* param ) {


### PR DESCRIPTION
vTaskDelete(0) always deletes the current task. Not great when you want to cancel a task from another context :)